### PR TITLE
Update plugin to work with 0.11 of Android plugin

### DIFF
--- a/src/main/groovy/me/champeau/gradle/GroovyAndroidPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/GroovyAndroidPlugin.groovy
@@ -34,7 +34,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
                     sourceCompatibility = '1.6'
                     targetCompatibility = '1.6'
                     doFirst {
-                        def runtimeJars = project.plugins.find { it.class.name == 'com.android.build.gradle.AppPlugin' }.runtimeJars
+                        def runtimeJars = project.plugins.findPlugin("android").bootClasspath
                         classpath = project.files(runtimeJars) + classpath
                     }
                 }


### PR DESCRIPTION
The plugin was using a `runtimeJar` property of the Android `BasePlugin` that
is no longer available in version 0.11 of that plugin. Instead, we should use
the `bootClasspath` property, as described by [this blog comment](http://melix.github.io/blog/2014/06/grooid.html#comment-1423846638).
