### PR TITLE
Added Groovy Source Set

### DIFF
--- a/src/main/groovy/me/champeau/gradle/GroovyAndroidPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/GroovyAndroidPlugin.groovy
@@ -33,6 +33,11 @@ class GroovyAndroidPlugin implements Plugin<Project> {
                 exclude 'META-INF/groovy-release-info.properties'
             }
 
+            // Forces Android Studio to recognize groovy folder as code
+            sourceSets {
+              main.java.srcDir('src/main/groovy')
+            }
+
             def variants = plugin.class.name.endsWith('.LibraryPlugin')?libraryVariants:applicationVariants
 
             variants.all {


### PR DESCRIPTION
Android Studio currently doesn't recognize `src/main/groovy` as a source folder. This fixes that.
