### PR TITLE
Add language level options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,18 @@ recommended, for performance, memory and battery life, that you use `@CompileSta
 
 Details can be found on my [blog](http://melix.github.io/blog/2014/06/grooid.html) and [here for more technical details](http://melix.github.io/blog/2014/06/grooid2.html)
 
+Setting the Java language level
+--------------------------------
+
+The default language level for both source and target is `1.6`. You can change it by giving some options. Following example changes it to `1.7`. Note that you have to change Android Studio project settings as well if you use the IDE.
+
+```groovy
+
+project.androidGroovy {
+    sourceCompatibility = '1.7'
+    targetCompatibility = '1.7'
+}
+
+```
+
 

--- a/src/main/groovy/me/champeau/gradle/GroovyAndroidPlugin.groovy
+++ b/src/main/groovy/me/champeau/gradle/GroovyAndroidPlugin.groovy
@@ -6,6 +6,11 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.compile.JavaCompile
 
+class GroovyAndroidPluginExtension {
+    def String sourceCompatibility = '1.6'
+    def String targetCompatibility = '1.6'
+}
+
 /**
  * This is the main plugin file. Put a description of your plugin here.
  */
@@ -19,6 +24,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
     ]
 
     void apply(Project project) {
+        project.extensions.create("androidGroovy", GroovyAndroidPluginExtension)
 
         def plugin = project.plugins.findPlugin('android')?:project.plugins.findPlugin('android-library')
         if (!plugin) {
@@ -62,8 +68,8 @@ class GroovyAndroidPlugin implements Plugin<Project> {
              destinationDir = javaCompile.destinationDir
              classpath = javaCompile.classpath
              groovyClasspath = classpath
-             sourceCompatibility = '1.6'
-             targetCompatibility = '1.6'
+             sourceCompatibility = project.androidGroovy.sourceCompatibility
+             targetCompatibility = project.androidGroovy.targetCompatibility
              doFirst {
                  def runtimeJars = groovyPlugin.getRuntimeJars(project, plugin)
                  classpath = project.files(runtimeJars) + classpath


### PR DESCRIPTION
This addresses #12 by adding `groovyAndroid` extension which has `sourceCompability` and `targetCompatibility` options. 
