### PR TITLE
Support for Android plugin 1.1 unit tests

### DIFF
--- a/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -60,6 +60,13 @@ class GroovyAndroidPlugin implements Plugin<Project> {
                 def flavors = it.productFlavors*.name
                 def types = it.buildType*.name
                 groovyPlugin.attachGroovyCompileTask(project, plugin, javaCompile, ['main', *flavors, *types])
+
+                // Unit tests (android plugin >= 1.1.0)
+                def unitTestTaskName = javaCompile.name.replace('Java', 'UnitTestJava')
+                def unitTestCompile = project[unitTestTaskName]
+                if (unitTestCompile != null) {
+                    groovyPlugin.attachGroovyCompileTask(project, plugin, unitTestCompile, ['test'])
+                }
             }
             testVariants.all {
                 project.logger.debug("Configuring Groovy test variant $it.name")
@@ -72,11 +79,10 @@ class GroovyAndroidPlugin implements Plugin<Project> {
             sourceSets {
                 main.java.srcDir('src/main/groovy')
                 androidTest.java.srcDir('src/androidTest/groovy')
+                test.java.srcDir('src/test/groovy')
             }
         }
         project.logger.info("Detected Android plugin version ${getAndroidPluginVersion(project)}")
-
-
     }
 
      private void attachGroovyCompileTask(Project project, Plugin plugin, JavaCompile javaCompile, List<String> srcDirs) {


### PR DESCRIPTION
I was trying to make Spock tests for a "normal" Java Android project, something that I think might be of great interest for much people. I realized that it wasn't possible yet to do it in the same module where the code is, although it's something possible in the Android gradle plugin since version 1.1.0. This change seems to be working fine for me, unit tests are executed correctly and Android Studio recognizes "src/test/groovy" as a valid source code directory.