### PR TITLE
Support for android plugin 1.3.0

### DIFF
--- a/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -62,7 +62,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
                 groovyPlugin.attachGroovyCompileTask(project, plugin, javaCompile, ['main', *flavors, *types])
 
                 // Unit tests (android plugin >= 1.1.0)
-                def unitTestTaskName = javaCompile.name.replace('Java', 'UnitTestJava')
+                def unitTestTaskName = javaCompile.name.replaceFirst('Java', 'UnitTestJava')
                 def unitTestCompile = project.getTasksByName(unitTestTaskName,false)
                 if (unitTestCompile) {
                     unitTestCompile.each { task ->


### PR DESCRIPTION
Compile task names are called compileJava**WithJavac** since android plugin 1.3.0. Method replaceFirst is used to transform task "compileJavaWithJavac" to "compileUnitTestJavaWithJavac" but not to "compileUnitTestJavaWithUnitTestJavac".