### PR TITLE
[IGNORE][CLOSED][Issue#59] adding src/groovy/test/ dir to compile dirs by groovy

### DIFF
--- a/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -74,7 +74,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
                 project.logger.debug("Configuring Groovy test variant $it.name")
                 def flavors = it.productFlavors*.name
                 def types = it.buildType*.name
-                groovyPlugin.attachGroovyCompileTask(project, plugin, javaCompile, ['androidTest', *flavors, *types])
+                groovyPlugin.attachGroovyCompileTask(project, plugin, javaCompile, ['test','androidTest', *flavors, *types])
             }
 
             // Forces Android Studio to recognize groovy folder as code


### PR DESCRIPTION
I think this is a correct fix. 
I have tested and now my tests which are in src/test/groovy compile. 
