### PR TITLE
fix a misguide in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the 2.4.0 release and beyond, so you need to add the following repository to you
 
 ```groovy
 
-repository {
+repositories {
    jcenter() // or mavenCentral()
 }
 ```


### PR DESCRIPTION
I use the guild in the Readme, and failed the build
```groovy
repository {
    jcenter()
}
```

it actually should be 
```grooovy
repositories {
    jcenter()
}
``