### PR TITLE
Fix to previous commit, that broke runtimeJars to versions 1.2.x and 1.3.x

### DIFF
--- a/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -100,7 +100,8 @@ class GroovyAndroidPlugin implements Plugin<Project> {
              classpath = javaCompile.classpath
              groovyClasspath = classpath
              doFirst {
-                 def runtimeJars = groovyPlugin.getRuntimeJars(project, plugin)
+                 def pluginVersion = getAndroidPluginVersion(project)
+                 def runtimeJars = groovyPlugin.getRuntimeJars(pluginVersion, plugin)
                  classpath = project.files(runtimeJars) + classpath
              }
          }
@@ -115,7 +116,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
          }
      }
 
-    private String getAndroidPluginVersion(Project project) {
+    String getAndroidPluginVersion(Project project) {
 
         def dependency = [project,project.rootProject].collect {
             it.buildscript.configurations.classpath.resolvedConfiguration.firstLevelModuleDependencies.find {
@@ -131,9 +132,15 @@ class GroovyAndroidPlugin implements Plugin<Project> {
         LATEST_SUPPORTED
     }
 
-    def getRuntimeJars(Project project, plugin) {
+    def getRuntimeJars(pluginVersion, plugin) {
+        int index = getRuntimeJarsIndex(pluginVersion)
+        def fun = RUNTIMEJARS_COMPAT[index]
+        fun(plugin)
+    }
+
+    int getRuntimeJarsIndex(pluginVersion) {
         int index
-        switch (getAndroidPluginVersion(project)) {
+        switch (pluginVersion) {
             case ~/0\.9\..*/:
                 index = 0
                 break
@@ -148,6 +155,12 @@ class GroovyAndroidPlugin implements Plugin<Project> {
             case ~/1\.1\..*/:
                 index = 2
                 break
+            case ~/1\.2\..*/:
+                index = 2
+                break
+            case ~/1\.3\..*/:
+                index = 2
+                break
             case ~/1\.4\.0-beta1*/:
                 index = 2
                 break
@@ -155,9 +168,8 @@ class GroovyAndroidPlugin implements Plugin<Project> {
                 index = 3
                 break
             default:
-                index = RUNTIMEJARS_COMPAT.size()-1
+                index = RUNTIMEJARS_COMPAT.size() - 1
         }
-        def fun = RUNTIMEJARS_COMPAT[index]
-        fun(plugin)
+        index
     }
 }

--- a/src/test/groovy/groovyx/grooid/GroovyAndroidPluginTest.groovy
+++ b/src/test/groovy/groovyx/grooid/GroovyAndroidPluginTest.groovy
@@ -1,0 +1,110 @@
+package groovyx.grooid
+
+import org.junit.Test
+
+/**
+ * Tests for GroovyAndroidPlugin
+ */
+class GroovyAndroidPluginTest {
+
+    //index 0: runtimeJars
+    //index 1: bootClasspath
+    //index 2: androidBuilder.bootClasspath
+    //index 3: androidBuilder.getBootClasspath(boolean)
+
+    @Test
+    void testRuntimeJarsFromVersion0() {
+        assert 0 == getRuntimeJarsIndex('0.9.0')
+        assert 0 == getRuntimeJarsIndex('0.9.1')
+        assert 0 == getRuntimeJarsIndex('0.9.2')
+
+        //it seems that in version 0.10.0, runtime jars changed from runtimeJars to bootClasspath
+        assert 1 == getRuntimeJarsIndex('0.10.0')
+        assert 1 == getRuntimeJarsIndex('0.10.1')
+        assert 1 == getRuntimeJarsIndex('0.10.2')
+        assert 1 == getRuntimeJarsIndex('0.10.4')
+        assert 1 == getRuntimeJarsIndex('0.11.0')
+        assert 1 == getRuntimeJarsIndex('0.11.1')
+        assert 1 == getRuntimeJarsIndex('0.11.2')
+        assert 1 == getRuntimeJarsIndex('0.12.0')
+        assert 1 == getRuntimeJarsIndex('0.12.1')
+        assert 1 == getRuntimeJarsIndex('0.12.2')
+        assert 1 == getRuntimeJarsIndex('0.13.0')
+        assert 1 == getRuntimeJarsIndex('0.13.1')
+        assert 1 == getRuntimeJarsIndex('0.13.2')
+        assert 1 == getRuntimeJarsIndex('0.13.3')
+        assert 1 == getRuntimeJarsIndex('0.14.0')
+        assert 1 == getRuntimeJarsIndex('0.14.1')
+        assert 1 == getRuntimeJarsIndex('0.14.2')
+        assert 1 == getRuntimeJarsIndex('0.14.3')
+        assert 1 == getRuntimeJarsIndex('0.14.4')
+    }
+
+    @Test
+    void testRuntimeJarsFromVersion1_0() {
+        assert 1 == getRuntimeJarsIndex('1.0.0')
+        assert 1 == getRuntimeJarsIndex('1.0.0-rc1')
+        assert 1 == getRuntimeJarsIndex('1.0.0-rc2')
+        assert 1 == getRuntimeJarsIndex('1.0.0-rc3')
+        assert 1 == getRuntimeJarsIndex('1.0.0-rc4')
+        assert 1 == getRuntimeJarsIndex('1.0.1')
+    }
+
+    @Test
+    void testRuntimeJarsFromVersion1_1() {
+        //In version 1.1, runtime jars changed from bootClasspath to androidBuilder.bootClasspath
+        assert 2 == getRuntimeJarsIndex('1.1.0')
+        assert 2 == getRuntimeJarsIndex('1.1.0-rc1')
+        assert 2 == getRuntimeJarsIndex('1.1.0-rc2')
+        assert 2 == getRuntimeJarsIndex('1.1.0-rc3')
+        assert 2 == getRuntimeJarsIndex('1.1.1')
+        assert 2 == getRuntimeJarsIndex('1.1.2')
+        assert 2 == getRuntimeJarsIndex('1.1.3')
+    }
+
+    @Test
+    void testRuntimeJarsFromVersion1_2() {
+        assert 2 == getRuntimeJarsIndex('1.2.0')
+        assert 2 == getRuntimeJarsIndex('1.2.0-beta1')
+        assert 2 == getRuntimeJarsIndex('1.2.0-beta2')
+        assert 2 == getRuntimeJarsIndex('1.2.0-beta3')
+        assert 2 == getRuntimeJarsIndex('1.2.0-beta4')
+        assert 2 == getRuntimeJarsIndex('1.2.0-rc1')
+        assert 2 == getRuntimeJarsIndex('1.2.1')
+        assert 2 == getRuntimeJarsIndex('1.2.2')
+        assert 2 == getRuntimeJarsIndex('1.2.3')
+    }
+
+    @Test
+    void testRuntimeJarsFromVersion1_3() {
+        assert 2 == getRuntimeJarsIndex('1.3.0')
+        assert 2 == getRuntimeJarsIndex('1.3.0-beta1')
+        assert 2 == getRuntimeJarsIndex('1.3.0-beta2')
+        assert 2 == getRuntimeJarsIndex('1.3.0-beta3')
+        assert 2 == getRuntimeJarsIndex('1.3.0-beta4')
+        assert 2 == getRuntimeJarsIndex('1.3.1')
+    }
+
+    @Test
+    void testRuntimeJarsFromVersion1_4() {
+        assert 2 == getRuntimeJarsIndex('1.4.0-beta1')
+
+        //In version 1.4.0-beta2, runtime jars changed from androidBuilder.getBootClasspath()
+        //to androidBuilder.getBootClasspath(boolean)
+        //The boolean parameter seems to indicate the inclusion of legacy jars (HTTP)
+        assert 3 == getRuntimeJarsIndex('1.4.0-beta2')
+        assert 3 == getRuntimeJarsIndex('1.4.0-beta3')
+    }
+
+    @Test
+    void testRuntimeJarsFromExpectedVersions() {
+        assert 3 == getRuntimeJarsIndex('1.5.0')
+        assert 3 == getRuntimeJarsIndex('1.5.0-beta1')
+        assert 3 == getRuntimeJarsIndex('1.5.0-rc1')
+    }
+
+    private static int getRuntimeJarsIndex(String version) {
+        new TestableGroovyAndroidPlugin(version).runtimeJarsIndex
+    }
+}
+

--- a/src/test/groovy/groovyx/grooid/TestableGroovyAndroidPlugin.groovy
+++ b/src/test/groovy/groovyx/grooid/TestableGroovyAndroidPlugin.groovy
@@ -1,0 +1,21 @@
+package groovyx.grooid
+
+import groovy.transform.Canonical
+import org.gradle.api.Project
+
+/**
+ * Class that overrides the getAndroidPluginVersion(Project) to make it testable
+ */
+@Canonical
+class TestableGroovyAndroidPlugin extends GroovyAndroidPlugin {
+    String androidPluginVersion
+
+    @Override
+    String getAndroidPluginVersion(Project project) {
+        androidPluginVersion
+    }
+
+    int getRuntimeJarsIndex() {
+        getRuntimeJarsIndex(androidPluginVersion)
+    }
+}


### PR DESCRIPTION
- Fixed getRuntimeJars, to return correct runtimeJars for version 1.2.x and 1.3.x (broken in previous commit)

- Simple refactorings to GroovyAndroidPlugin, to facilitate testing:
  1. new method getRuntimeJarsIndex(pluginVersion), refactored from getRuntimeJars(project, plugin)
  2. getRuntimeJars(project, plugin) to getRuntimeJars(pluginVersion, plugin)
- Added GroovyAndroidPluginTest to ensure that all supported versions of the build plugin are getting the correct runtime jars