### PR TITLE
update Groovy compilation task's classpath first when execute it

### DIFF
--- a/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -104,7 +104,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
                 // "com.android.support:support-v4:23.1.1"
                 // see https://github.com/groovy/groovy-android-gradle-plugin/pull/69
                 classpath = javaCompile.classpath
-                groovyClasspath = javaCompile.classpath // maybe don't need update this groovyClasspath
+                groovyClasspath = classpath
                 // add Android's bootstrap classpath
                 def pluginVersion = getAndroidPluginVersion(project)
                 def runtimeJars = getRuntimeJars(pluginVersion, plugin)

--- a/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -99,8 +99,10 @@ class GroovyAndroidPlugin implements Plugin<Project> {
             classpath = javaCompile.classpath
             groovyClasspath = classpath
             doFirst {
-                // update Groovy compilation task's classpath, to use the latest classpath which may be updated by other tasks
-                // !!!Note: groovyCompile should execute after javaCompile
+                // update the classpath of groovyCompile task, to use the latest classpath which may be updated
+                // by other tasks, task "prepareComAndroidSupportSupportV42311Library" for example when using
+                // "com.android.support:support-v4:23.1.1"
+                // see https://github.com/groovy/groovy-android-gradle-plugin/pull/69
                 classpath = javaCompile.classpath
                 groovyClasspath = javaCompile.classpath // maybe don't need update this groovyClasspath
                 // add Android's bootstrap classpath

--- a/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -96,8 +96,6 @@ class GroovyAndroidPlugin implements Plugin<Project> {
             project.androidGroovy.configure(it)
             source = srcDirsAsString.collect { project.fileTree(project.file(it)) }
             destinationDir = javaCompile.destinationDir
-            classpath = javaCompile.classpath
-            groovyClasspath = classpath
             doFirst {
                 def pluginVersion = getAndroidPluginVersion(project)
                 def runtimeJars = getRuntimeJars(pluginVersion, plugin)
@@ -105,6 +103,12 @@ class GroovyAndroidPlugin implements Plugin<Project> {
             }
         }
 
+        javaCompile.doLast {
+             // set Groovy compilation task's classpath when executing relevant Java compilation task,
+             // to use the latest classpath which may be updated by other tasks
+             groovyCompile.classpath = javaCompile.classpath
+             groovyCompile.groovyClasspath = javaCompile.classpath
+        }
         javaCompile.finalizedBy(groovyCompile)
         javaCompile.exclude { e ->
             // this is a dirty hack to work around the fact that we need to declare the source tree as Java sources


### PR DESCRIPTION
Update Groovy compilation task's classpath first, to use the latest classpath which may be updated by other tasks.
This assume groovyCompile execute after javaCompile.