### PR TITLE
Ability for GroovyC Compile all Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
       based off of JavaCompile's
     * Custom groovy sourceSets added. Java directories may be used to java be joint 
       compiled with groovy 
+    * Added flag in androidGroovy to skip JavaCompile and have GroovyCompile to all
+      compilation.
 0.3.8
 -----
     * Fixes issues for users not on Java 8. Supports Java 6+

--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ androidGroovy {
 
 See [GroovyCompile](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.GroovyCompile.html) for more options.
 
+Only Use GroovyC
+----------------
+
+For integration with previous projects or for working with generated files (such as BuildConfg)
+it may be desirable to only have GroovyC run in order to have Java files reference Groovy files.
+In order to do this the flag `skipJavaC` in the androidGroovy block should be set to true.
+
+```groovy
+androidGroovy {
+  skipJavaC = true
+}
+```
+
+This will remove all the files from the JavaC tasks and them all to GroovyC.
 
 Android `packagingOptions`
 --------------------------

--- a/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidExtension.groovy
+++ b/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidExtension.groovy
@@ -32,9 +32,19 @@ import org.gradle.util.ConfigureUtil
  */
 class GroovyAndroidExtension {
 
-  private Closure<Void> configClosure
+  /**
+   * Setting this flag to true will have only groovyc run instead of javac then groovyc run
+   * This will effectively have all code (java and groovy) be joint compiled. This is
+   * useful for adding groovy into older projects, and for having generated
+   * code be able to utilize groovy code.
+   *
+   * @param skipJavaC
+   */
+  boolean skipJavaC
 
   final NamedDomainObjectContainer<GroovySourceSet> sourceSetsContainer
+
+  private Closure<Void> configClosure
 
   GroovyAndroidExtension(Project project, Instantiator instantiator, FileResolver fileResolver) {
     sourceSetsContainer = project.container(GroovySourceSet, new AndroidGroovySourceSetFactory(instantiator, fileResolver))

--- a/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -129,6 +129,13 @@ class GroovyAndroidPlugin implements Plugin<Project> {
           project.logger.debug("Eexlude against groovy files $groovySourceSet.groovy.files")
           file.file in groovySourceSet.groovy.files
         }
+
+        if (extension.skipJavaC) {
+          groovyTask.source(*(javaTask.source.files as List))
+          javaTask.exclude {
+            true
+          }
+        }
       }
 
 

--- a/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/GroovyAndroidPluginSpec.groovy
+++ b/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/GroovyAndroidPluginSpec.groovy
@@ -124,7 +124,7 @@ class GroovyAndroidPluginSpec extends Specification implements AndroidFileHelper
 
     when:
     project.evaluate()
-    def groovyTasks = project.tasks.findAll { it.name.contains('Groovy') }
+    def groovyTasks = project.tasks.findAll { it.name.contains('Groovyc') }
 
     then:
     groovyTasks.each { task ->

--- a/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/functional/FullCompilationSpec.groovy
+++ b/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/functional/FullCompilationSpec.groovy
@@ -25,10 +25,10 @@ import static groovyx.grooid.internal.TestProperties.allTests
  * Complete test suite to ensure the plugin works with the different versions of android gradle plugin.
  * This will only be run if the system property of 'allTests' is set to true
  */
+@IgnoreIf({ !allTests })
 class FullCompilationSpec extends FunctionalSpec {
 
   @Unroll
-  @IgnoreIf({ !allTests })
   def "should compile android app with java:#javaVersion, android plugin:#androidPluginVersion"() {
     given:
     file("settings.gradle") << "rootProject.name = 'test-app'"
@@ -237,7 +237,6 @@ class FullCompilationSpec extends FunctionalSpec {
   }
 
   @Unroll
-  @IgnoreIf({ !allTests })
   def "should compile android library with java:#javaVersion and android plugin:#androidPluginVersion"() {
     given:
     file("settings.gradle") << "rootProject.name = 'test-lib'"

--- a/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/functional/RenderScriptCompilationSpec.groovy
+++ b/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/functional/RenderScriptCompilationSpec.groovy
@@ -16,12 +16,17 @@
 
 package groovyx.grooid.functional
 
+import spock.lang.IgnoreIf
+
 import javax.imageio.ImageIO
 import java.awt.image.BufferedImage
+
+import static groovyx.grooid.internal.TestProperties.allTests
 
 /**
  * Ensure that projects with renderscript compile properly.
  */
+@IgnoreIf({ !allTests})
 class RenderScriptCompilationSpec extends FunctionalSpec {
 
   def "should compile with renderscript"() {

--- a/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/functional/SkipJavaCSpec.groovy
+++ b/gradle-groovy-android-plugin/src/test/groovy/groovyx/grooid/functional/SkipJavaCSpec.groovy
@@ -21,148 +21,7 @@ import spock.lang.IgnoreIf
 import static groovyx.grooid.internal.TestProperties.allTests
 
 @IgnoreIf({ !allTests })
-class SourceSetSpec extends FunctionalSpec {
-
-  def "should compile groovy files added to groovy sourceDirs"() {
-    file("settings.gradle") << "rootProject.name = 'test-app'"
-
-    buildFile << """
-      buildscript {
-        repositories {
-          maven { url "${localRepo.toURI()}" }
-          jcenter()
-        }
-        dependencies {
-          classpath 'com.android.tools.build:gradle:1.5.0'
-          classpath 'org.codehaus.groovy:gradle-groovy-android-plugin:$PLUGIN_VERSION'
-        }
-      }
-
-      apply plugin: 'com.android.application'
-      apply plugin: 'groovyx.grooid.groovy-android'
-
-      repositories {
-        jcenter()
-      }
-
-      android {
-        compileSdkVersion 23
-        buildToolsVersion '23.0.2'
-
-        defaultConfig {
-          minSdkVersion 16
-          targetSdkVersion 23
-
-          versionCode 1
-          versionName '1.0.0'
-
-          testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
-        }
-
-        buildTypes {
-          debug {
-            applicationIdSuffix '.dev'
-          }
-        }
-
-        compileOptions {
-          sourceCompatibility '1.7'
-          targetCompatibility '1.7'
-        }
-      }
-
-      androidGroovy {
-        sourceSets {
-          main {
-            groovy.srcDirs += 'src/example/groovy'
-          }
-        }
-      }
-
-      dependencies {
-        compile 'org.codehaus.groovy:groovy:2.4.5:grooid'
-      }
-    """
-
-    file('src/main/AndroidManifest.xml') << """
-      <?xml version="1.0" encoding="utf-8"?>
-      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="groovyx.grooid.test">
-
-        <application
-            android:allowBackup="true"
-            android:label="Test App">
-          <activity
-              android:name=".MainActivity"
-              android:label="Test App">
-            <intent-filter>
-              <action android:name="android.intent.action.MAIN"/>
-              <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-          </activity>
-        </application>
-
-      </manifest>
-    """.trim()
-
-    file('src/main/res/layout/activity_main.xml') << """
-      <?xml version="1.0" encoding="utf-8"?>
-      <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-          android:layout_width="match_parent"
-          android:layout_height="match_parent"
-      >
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Hello Groovy!"
-            android:gravity="center"
-            android:textAppearance="?android:textAppearanceLarge"
-        />
-
-      </FrameLayout>
-    """.trim()
-
-    file('src/example/groovy/groovyx/grooid/test/ExampleGroovy.groovy') << """
-      package groovyx.grooid.test
-
-      import groovy.transform.CompileStatic
-
-      @CompileStatic
-      class ExampleGroovy {
-        String getCoolString() {
-          'this is a cool string'
-        }
-      }
-    """
-
-    file('src/main/groovy/groovyx/grooid/test/MainActivity.groovy') << """
-      package groovyx.grooid.test
-
-      import android.app.Activity
-      import android.os.Bundle
-      import groovy.transform.CompileStatic
-
-      @CompileStatic
-      class MainActivity extends Activity {
-        @Override void onCreate(Bundle savedInstanceState) {
-          super.onCreate(savedInstanceState)
-          contentView = R.layout.activity_main
-
-          new ExampleGroovy().coolString
-        }
-      }
-    """
-
-    when:
-    run 'assemble'
-
-    then:
-    noExceptionThrown()
-    file('build/outputs/apk/test-app-debug.apk').exists()
-    file('build/intermediates/classes/debug/groovyx/grooid/test/MainActivity.class').exists()
-    file('build/intermediates/classes/debug/groovyx/grooid/test/ExampleGroovy.class').exists()
-  }
+class SkipJavaCSpec extends FunctionalSpec {
 
   def "should joint compile java files added to groovy sourceDirs"() {
     file("settings.gradle") << "rootProject.name = 'test-app'"
@@ -213,11 +72,7 @@ class SourceSetSpec extends FunctionalSpec {
       }
 
       androidGroovy {
-        sourceSets {
-          main {
-            groovy.srcDirs += 'src/main/java'
-          }
-        }
+        skipJavaC = true
       }
 
       dependencies {
@@ -304,6 +159,7 @@ class SourceSetSpec extends FunctionalSpec {
     """
 
     when:
+    copyTestDir()
     run 'assemble'
 
     then:


### PR DESCRIPTION
A flag was added to the plugin `androidGroovy.skipJavaC` that when
set to true will exclude all sources in the JavaCompile task
and will add them to the GroovyCompile task.