### PR TITLE
Update GroovyAndroidPlugin Java Sources

### DIFF
--- a/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
+++ b/gradle-groovy-android-plugin/src/main/groovy/groovyx/grooid/GroovyAndroidPlugin.groovy
@@ -69,7 +69,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
         def sourceSetPath = project.file("src/$sourceSetName/groovy")
 
         // add so Android Studio will recognize groovy files can see these
-        sourceSet.java.srcDirs.add(sourceSetPath)
+        sourceSet.java.srcDir(sourceSetPath)
 
         // create groovy source set so we can access it later
         def groovySourceSet = extension.sourceSetsContainer.maybeCreate(sourceSetName)


### PR DESCRIPTION
This fixes an issue where the groovy sources were not being applied correctly to the java
sources, causing these folders to not show up as source folders automatically by Android Studio.