### PR TITLE
Minor Text Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:2.1.2'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
     //noinspection GradleDynamicVersion (this gets replaced by androidGroovyLocal.gradle)
-    classpath 'org.codehaus.groovy:gradle-groovy-android-plugin:+'
+    classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:+'
   }
 }
 

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/CompilationSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/CompilationSpec.groovy
@@ -25,7 +25,7 @@ import static groovyx.internal.TestProperties.compileSdkVersion
  */
 class CompilationSpec extends FunctionalSpec {
 
-  def "should compile android app with java:#javaVersion, android plugin:#androidPluginVersion"() {
+  def "should compile android app"() {
     given:
     file("settings.gradle") << "rootProject.name = 'test-app'"
 
@@ -213,7 +213,7 @@ class CompilationSpec extends FunctionalSpec {
     file('build/intermediates/classes/test/release/groovyx/test/JvmTest.class').exists()
   }
 
-  def "should compile android library with java:#javaVersion and android plugin:#androidPluginVersion"() {
+  def "should compile android library"() {
     given:
     file("settings.gradle") << "rootProject.name = 'test-lib'"
 


### PR DESCRIPTION
- Updated Compilation Spec Text. No JavaVersion
or Gradle Version supplied for printing out.
- Updated build.gradle to use the path of the 1.0.0 plugin.
This was being overriden by buildSrc, but when you want to
comment this out for intellij this is nice.