### PR TITLE
Removed direct dependency on Android Gradle Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 1.1.0
 -----
     * Support for 2.2.0 of Android Gradle Plugin
+    * Removed direct dependency on Android Gradle Plugin (#127)
 1.0.0
 -----
     * Renamed plugin id from 'groovyx.grooid.groovy-android' to 'groovyx.android'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.2.0'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
+    classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.1.0'
   }
 }
 

--- a/groovy-android-gradle-plugin/gradle-plugin.gradle
+++ b/groovy-android-gradle-plugin/gradle-plugin.gradle
@@ -16,6 +16,7 @@
 
 apply plugin: 'groovy'
 apply plugin: 'maven'
+apply plugin: 'nebula.optional-base'
 apply from: "$rootDir/gradle/publishing.gradle"
 apply from: "$rootDir/gradle/bintray.gradle"
 apply from: "$rootDir/gradle/artifactory.gradle"
@@ -31,7 +32,7 @@ dependencies {
   compile localGroovy()
   compile gradleApi()
 
-  compile "com.android.tools.build:gradle:$androidPluginVersion"
+  compile "com.android.tools.build:gradle:$androidPluginVersion", optional
 
   testCompile gradleTestKit()
   testCompile "org.spockframework:spock-core:$spockVersion", {

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/FullCompilationSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/FullCompilationSpec.groovy
@@ -37,11 +37,6 @@ class FullCompilationSpec extends FunctionalSpec {
 
     buildFile << """
       buildscript {
-        // Workaround for com.android.application plugin failing when
-        // trying to run tests with gradle versions older than 2.14.1
-        // TODO: check compatibility issues
-        System.properties['com.android.build.gradle.overrideVersionCheck'] = 'true'
-
         repositories {
           maven { url "${localRepo.toURI()}" }
           jcenter()
@@ -80,8 +75,8 @@ class FullCompilationSpec extends FunctionalSpec {
         }
 
         compileOptions {
-          sourceCompatibility '$javaVersion'
-          targetCompatibility '$javaVersion'
+          sourceCompatibility $javaVersion
+          targetCompatibility $javaVersion
         }
       }
 
@@ -91,8 +86,6 @@ class FullCompilationSpec extends FunctionalSpec {
             encoding = 'UTF-8'
             forkOptions.jvmArgs = ['-noverify']
           }
-          sourceCompatibility = '$javaVersion'
-          targetCompatibility = '$javaVersion'
          }
       }
 
@@ -224,6 +217,7 @@ class FullCompilationSpec extends FunctionalSpec {
     """
 
     when:
+    copyTestDir()
     runWithVersion gradleVersion, 'assemble', 'test'
 
     then:
@@ -236,17 +230,17 @@ class FullCompilationSpec extends FunctionalSpec {
 
     where:
     // test common configs that touches the different way to access the classpath
-    javaVersion | androidPluginVersion | gradleVersion
-    '1.6'       | '1.1.0'              | '2.10'
-    '1.6'       | '1.3.0'              | '2.10'
-    '1.6'       | '1.5.0'              | '2.10'
-    '1.7'       | '1.5.0'              | '2.11'
-    '1.7'       | '1.5.0'              | '2.12' // added due to breaking changes in gradle 2.12
-    '1.7'       | '2.0.0'              | '2.13'
-    '1.7'       | '2.1.2'              | '2.14'
-    '1.7'       | '2.2.0'              | '2.14.1'
-    '1.7'       | '2.2.0'              | '3.0'
-    '1.7'       | '2.2.0'              | '3.1'
+    javaVersion                     | androidPluginVersion | gradleVersion
+    'JavaVersion.VERSION_1_6'       | '1.1.0'              | '2.2'
+    'JavaVersion.VERSION_1_6'       | '1.3.0'              | '2.2'
+    'JavaVersion.VERSION_1_6'       | '1.5.0'              | '2.10'
+    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.11'
+    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.12' // added due to breaking changes in gradle 2.12
+    'JavaVersion.VERSION_1_7'       | '2.0.0'              | '2.13'
+    'JavaVersion.VERSION_1_7'       | '2.1.2'              | '2.14'
+    'JavaVersion.VERSION_1_7'       | '2.2.0'              | '2.14.1'
+    'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.0'
+    'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.1'
   }
 
   @Unroll
@@ -286,8 +280,8 @@ class FullCompilationSpec extends FunctionalSpec {
         }
 
         compileOptions {
-          sourceCompatibility '$javaVersion'
-          targetCompatibility '$javaVersion'
+          sourceCompatibility $javaVersion
+          targetCompatibility $javaVersion
         }
       }
 
@@ -396,15 +390,15 @@ class FullCompilationSpec extends FunctionalSpec {
     where:
     // test common configs that touches the different way to access the classpath
     javaVersion | androidPluginVersion | gradleVersion
-    '1.6'       | '1.1.0'              | '2.10'
-    '1.6'       | '1.3.0'              | '2.10'
-    '1.6'       | '1.5.0'              | '2.10'
-    '1.7'       | '1.5.0'              | '2.11'
-    '1.7'       | '1.5.0'              | '2.12' // added due to breaking changes in gradle 2.12
-    '1.7'       | '2.0.0'              | '2.13'
-    '1.7'       | '2.1.2'              | '2.14'
-    '1.7'       | '2.2.0'              | '2.14.1'
-    '1.7'       | '2.2.0'              | '3.0'
-    '1.7'       | '2.2.0'              | '3.1'
+    'JavaVersion.VERSION_1_6'       | '1.1.0'              | '2.2'
+    'JavaVersion.VERSION_1_6'       | '1.3.0'              | '2.2'
+    'JavaVersion.VERSION_1_6'       | '1.5.0'              | '2.10'
+    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.11'
+    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.12' // added due to breaking changes in gradle 2.12
+    'JavaVersion.VERSION_1_7'       | '2.0.0'              | '2.13'
+    'JavaVersion.VERSION_1_7'       | '2.1.2'              | '2.14'
+    'JavaVersion.VERSION_1_7'       | '2.2.0'              | '2.14.1'
+    'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.0'
+    'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.1'
   }
 }


### PR DESCRIPTION
This removes the need to update the plugin with new dependencies as they come out
or have the users remove the dependent plugin and add the version they want for
their version.

#127 