### PR TITLE
Disable Groovy Task when No Sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-24.0.2
-    - android-24
+    - build-tools-25.0.2
+    - android-25
     - extra-google-m2repository
     - extra-android-m2repository
 
@@ -18,7 +18,7 @@ before_install:
   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
   - cat /etc/hosts # optionally check the content *after*
 
-script: ./gradlew -q -s -PbuildInfo.build.number=$TRAVIS_BUILD_NUMBER -PbuildInfo.buildUrl=https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_JOB_ID}
+script: ./gradlew -q -s -Dscan -PbuildInfo.build.number=$TRAVIS_BUILD_NUMBER -PbuildInfo.buildUrl=https://travis-ci.org/${TRAVIS_REPO_SLUG}/builds/${TRAVIS_JOB_ID}
   -PbuildInfo.buildAgent.name=$USER -PbuildInfo.principal=$USER --debug --info clean assemble check fullTest artifactoryPublish
 
 branches:

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@
 buildscript {
   repositories {
     jcenter()
+    maven { url 'https://plugins.gradle.org/m2/' }
   }
 
   dependencies {
@@ -24,11 +25,13 @@ buildscript {
     classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:1.0.0'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.2.0'
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
+    classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
     classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.1.0'
+    classpath 'com.gradle:build-scan-plugin:1.6'
   }
 }
 
+apply plugin: 'com.gradle.build-scan'
 apply from: "$rootDir/gradle/idea/idea.gradle"
 
 allprojects {
@@ -48,13 +51,18 @@ subprojects {
   }
 }
 
+buildScan {
+  licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+  licenseAgree = 'yes'
+}
+
 ext {
   androidPluginVersion = androidPluginVersion
-  buildToolsVersion = '24.0.2'
-  compileSdkVersion = 24
-  spockVersion = '1.1-groovy-2.4-rc-2'
+  buildToolsVersion = '25.0.2'
+  compileSdkVersion = 25
+  spockVersion = '1.1-groovy-2.4-rc-4'
   androidSupportTestVersion = '0.5'
-  groovyVersion = '2.4.7'
+  groovyVersion = '2.4.10'
 }
 
 task prepareRelease(type: Exec) {

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/GroovyAndroidPluginSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/GroovyAndroidPluginSpec.groovy
@@ -16,12 +16,14 @@
 
 package groovyx
 
+import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.api.AndroidSourceSet
 import groovyx.internal.AndroidFileHelper
 import groovyx.internal.AndroidPluginHelper
 import groovyx.internal.TestProperties
 import org.gradle.api.Project
 import org.gradle.api.tasks.GroovySourceSet
+import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -89,12 +91,12 @@ class GroovyAndroidPluginSpec extends Specification implements AndroidFileHelper
       compileSdkVersion TestProperties.getCompileSdkVersion()
     }
 
-    // Android Plugin Reqires this file to exist with parsable XML
+    // Android Plugin Requires this file to exist with parsable XML
     createSimpleAndroidManifest()
 
     when:
     project.evaluate()
-    def groovyTasks = project.tasks.findAll { it.name.contains('Groovy') }
+    def groovyTasks = project.tasks.withType(GroovyCompile)
     def taskNames = groovyTasks.collect { it.name }
 
     then:
@@ -125,7 +127,7 @@ class GroovyAndroidPluginSpec extends Specification implements AndroidFileHelper
 
     when:
     project.evaluate()
-    def groovyTasks = project.tasks.findAll { it.name.contains('Groovyc') }
+    def groovyTasks = project.tasks.withType(GroovyCompile)
 
     then:
     groovyTasks.each { task ->
@@ -137,6 +139,27 @@ class GroovyAndroidPluginSpec extends Specification implements AndroidFileHelper
     version | _
     '1.6'   | _
     '1.7'   | _
+  }
+
+  def "should not enable groovy tasks if no source set"() {
+    given:
+    project.with {
+      pluginManager.apply(AppPlugin)
+      pluginManager.apply(GroovyAndroidPlugin)
+      android {
+        buildToolsVersion TestProperties.getBuildToolsVersion()
+        compileSdkVersion TestProperties.getCompileSdkVersion()
+      }
+    }
+
+    // Android Plugin Requires this file to exist with parsable XML
+    createSimpleAndroidManifest()
+
+    when:
+    project.evaluate()
+
+    then:
+    project.tasks.withType(GroovyCompile).size() == 0
   }
 }
 

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/FullCompilationSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/FullCompilationSpec.groovy
@@ -234,12 +234,15 @@ class FullCompilationSpec extends FunctionalSpec {
     'JavaVersion.VERSION_1_6'       | '1.3.0'              | '2.2'
     'JavaVersion.VERSION_1_6'       | '1.5.0'              | '2.10'
     'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.11'
-    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.12' // added due to breaking changes in gradle 2.12
+    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.12'
     'JavaVersion.VERSION_1_7'       | '2.0.0'              | '2.13'
     'JavaVersion.VERSION_1_7'       | '2.1.2'              | '2.14'
     'JavaVersion.VERSION_1_7'       | '2.2.0'              | '2.14.1'
     'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.0'
     'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.1'
+    'JavaVersion.VERSION_1_6'       | '2.2.3'              | '3.2'
+    'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.3'
+    'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.4'
   }
 
   @Unroll
@@ -393,11 +396,14 @@ class FullCompilationSpec extends FunctionalSpec {
     'JavaVersion.VERSION_1_6'       | '1.3.0'              | '2.2'
     'JavaVersion.VERSION_1_6'       | '1.5.0'              | '2.10'
     'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.11'
-    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.12' // added due to breaking changes in gradle 2.12
+    'JavaVersion.VERSION_1_7'       | '1.5.0'              | '2.12'
     'JavaVersion.VERSION_1_7'       | '2.0.0'              | '2.13'
     'JavaVersion.VERSION_1_7'       | '2.1.2'              | '2.14'
     'JavaVersion.VERSION_1_7'       | '2.2.0'              | '2.14.1'
     'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.0'
     'JavaVersion.VERSION_1_7'       | '2.2.0'              | '3.1'
+    'JavaVersion.VERSION_1_6'       | '2.2.3'              | '3.2'
+    'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.3'
+    'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.4'
   }
 }

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/internal/AndroidPluginHelper.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/internal/AndroidPluginHelper.groovy
@@ -25,16 +25,25 @@ import org.gradle.api.Project
 trait AndroidPluginHelper {
   void applyAppPlugin() {
     project.pluginManager.apply(AppPlugin)
+    createSourceDirs()
     project.pluginManager.apply(GroovyAndroidPlugin)
   }
 
   void applyLibraryPlugin() {
     project.pluginManager.apply(LibraryPlugin)
+    createSourceDirs()
     project.pluginManager.apply(GroovyAndroidPlugin)
   }
 
   GroovyAndroidExtension getExtension() {
     project.extensions.getByType(GroovyAndroidExtension)
+  }
+
+  private void createSourceDirs() {
+    def sourceSets = project.extensions.getByName('android').sourceSets
+    sourceSets.each {
+      project.file("src/$it.name/groovy").mkdirs()
+    }
   }
 
   abstract Project getProject()

--- a/groovy-android-sample-app/sample-app.gradle
+++ b/groovy-android-sample-app/sample-app.gradle
@@ -21,7 +21,7 @@ apply from: "$rootDir/gradle/extraAndroidTasks.gradle"
 description = 'Sample project showing how to use Goovy on Android - http://www.groovy-lang.org'
 
 android {
-  compileSdkVersion 24
+  compileSdkVersion 25
   buildToolsVersion rootProject.buildToolsVersion
 
   defaultConfig {


### PR DESCRIPTION
Source sets with no groovy sources are are skipped by default
this should speed up builds and allow groovy to only be used
for tests while Java and/or Kotlin are in the main source set.

relates to #119 and #139