### PR TITLE
Updated to Gradle 3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.0'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:1.0.0'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.2.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 20 10:41:30 CDT 2016
+#Fri Apr 14 08:59:00 CDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip

--- a/groovy-android-gradle-plugin/src/main/groovy/groovyx/internal/DefaultAndroidGroovySourceSet.groovy
+++ b/groovy-android-gradle-plugin/src/main/groovy/groovyx/internal/DefaultAndroidGroovySourceSet.groovy
@@ -17,6 +17,7 @@
 package groovyx.internal
 
 import groovyx.api.AndroidGroovySourceSet
+import org.gradle.api.Action
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.file.FileResolver
@@ -48,6 +49,15 @@ class DefaultAndroidGroovySourceSet implements AndroidGroovySourceSet {
       allGroovy.source(groovy)
       allGroovy.filter.include("**/*.groovy")
     }
+  }
+
+  /**
+   * Looks like this was added in Gradle 3.3 which was causing breaking issues. Leave Override off
+   * to prevent issues.
+   */
+  GroovySourceSet groovy(Action<? super SourceDirectorySet> configureAction) {
+    configureAction.execute(groovy)
+    return this
   }
 
   @Override GroovySourceSet groovy(Closure configureClosure) {

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/FullCompilationSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/FullCompilationSpec.groovy
@@ -243,6 +243,7 @@ class FullCompilationSpec extends FunctionalSpec {
     'JavaVersion.VERSION_1_6'       | '2.2.3'              | '3.2'
     'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.3'
     'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.4'
+    'JavaVersion.VERSION_1_7'       | '2.3.1'              | '3.5'
   }
 
   @Unroll
@@ -391,7 +392,7 @@ class FullCompilationSpec extends FunctionalSpec {
 
     where:
     // test common configs that touches the different way to access the classpath
-    javaVersion | androidPluginVersion | gradleVersion
+    javaVersion                     | androidPluginVersion | gradleVersion
     'JavaVersion.VERSION_1_6'       | '1.1.0'              | '2.2'
     'JavaVersion.VERSION_1_6'       | '1.3.0'              | '2.2'
     'JavaVersion.VERSION_1_6'       | '1.5.0'              | '2.10'
@@ -405,5 +406,6 @@ class FullCompilationSpec extends FunctionalSpec {
     'JavaVersion.VERSION_1_6'       | '2.2.3'              | '3.2'
     'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.3'
     'JavaVersion.VERSION_1_7'       | '2.3.0'              | '3.4'
+    'JavaVersion.VERSION_1_7'       | '2.3.1'              | '3.5'
   }
 }


### PR DESCRIPTION
Updated to Gradle 3.5 from 2.14. Updated tests to include Gradle 3.5.
Fixed breaking change from Gradle 3.2 to 3.3 where the GroovySourceSet
interface had a method added to it.