### PR TITLE
Updated Docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
-:groovyVersion: 2.4.7
+:groovyVersion: 2.4.10
 :pluginVersion: 1.1.0
 :pluginSnapshotVersion: 1.2.0
-:androidPluginVersion: 2.2.0
+:androidPluginVersion: 2.2.3
 
 = Groovy language support for Android
 
@@ -136,6 +136,24 @@ compile ('org.codehaus.groovy:groovy-xml:2.4.3') {
 }
 ----
 
+== Skipping Groovy Compile
+
+As of version 1.2.0 only build types/build flavors with groovy sources included in them will have
+the groovy compile task added. If you would like to skip the groovy compilation tasks on older
+versions or on newer version wish to skip them in build types that have groovy sources you can use
+the following to disable the groovy compiler task.
+
+[source, groovy]
+```
+tasks.whenTaskAdded { task ->
+  if (task.name == 'compileDebugGroovyWithGroovyc') {
+    task.enabled = false
+  }
+}
+```
+
+This example disables groovy compilation only for the debug build type, simply replace
+`compileDebugGroovyWithGroovyc` with whichever compilation task you would like skip to disable it.
 
 == Configuring the Groovy compilation options
 

--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -1,0 +1,6 @@
+= How to Release
+
+. Prepare for release `./gradlew prepareRelease`
+. Update Version Number: remove -SNAPSHOT and commit the change
+. Run release task `./gradlew release`
+. Update Version Number in build.gradle and README.adoc

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,0 @@
-# How to Release
-
-1) Prepare for release `./gradlew prepareRelease`
-1) Update Version Number: remove -SNAPSHOT and commit the change
-1) Run release task `./gradlew release`
-1) Update Version Number in build.gradle and README.adoc


### PR DESCRIPTION
README:
- added info on skipping groovy compile tasks (#144)
- updated android Gradle plugin version and groovy library version

RELEASE:
- Converted to asciidoc