### PR TITLE
Allow Groovy to compile with Kotlin references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 -----
     * Added support for annotation processing (#142)
     * Disabled groovy task for when there are no groovy sources
+    * Kotlin Support - Kotlin plugin applied before Groovy plugin will allow the Groovy compiler
+    to know about the Kotlin source files. (#139)
     * Dropped support for Android Gradle Plugin Versions < 1.5.0
 1.1.0
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.2.0'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
     classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.1.0'
-    classpath 'com.gradle:build-scan-plugin:1.6'
+    classpath 'com.gradle:build-scan-plugin:1.7.4'
     classpath 'com.gradle.publish:plugin-publish-plugin:0.9.7'
   }
 }

--- a/groovy-android-gradle-plugin/gradle-plugin.gradle
+++ b/groovy-android-gradle-plugin/gradle-plugin.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ dependencies {
 
   testCompile gradleTestKit()
   testCompile "org.spockframework:spock-core:$spockVersion", {
-    exclude group: "org.codehaus.groovy", module: 'groovy-all'
+    exclude group: 'org.codehaus.groovy', module: 'groovy-all'
   }
 }
 

--- a/groovy-android-gradle-plugin/src/main/groovy/groovyx/GroovyAndroidPlugin.groovy
+++ b/groovy-android-gradle-plugin/src/main/groovy/groovyx/GroovyAndroidPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.android.build.gradle.internal.variant.BaseVariantData
 import com.android.build.gradle.internal.variant.BaseVariantOutputData
 import com.android.builder.model.SourceProvider
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -40,6 +41,7 @@ import javax.inject.Inject
 /**
  * Adds support for building Android applications using the Groovy language.
  */
+@Slf4j
 class GroovyAndroidPlugin implements Plugin<Project> {
 
   public static final String ANDROID_GROOVY_EXTENSION_NAME = 'androidGroovy'
@@ -84,7 +86,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
       def groovyDirSet = groovySourceSet.groovy
       groovyDirSet.srcDir(sourceSetPath)
 
-      project.logger.debug("Created groovy sourceDirectorySet at $groovyDirSet.srcDirs")
+      log.debug('Created groovy sourceDirectorySet at {}', groovyDirSet.srcDirs)
     }
 
     project.afterEvaluate { Project afterProject ->
@@ -100,11 +102,11 @@ class GroovyAndroidPlugin implements Plugin<Project> {
 
     variantDataList.each { variantData ->
       def variantDataName = variantData.name
-      project.logger.debug("Process variant [$variantDataName]")
+      log.debug('Process variant {}', variantDataName)
 
       def javaTask = getJavaTask(variantData)
       if (javaTask == null) {
-        project.logger.info("javaTask is missing for $variantDataName, so Groovy files won't be compiled for it")
+        log.info('javaTask is missing for {}, so Groovy files won\'t be compiled for it', variantDataName)
         return
       }
 
@@ -136,8 +138,6 @@ class GroovyAndroidPlugin implements Plugin<Project> {
 
         // Exclude any java files that may be included in both java and groovy source sets
         javaTask.exclude { file ->
-          project.logger.debug("Exclude java file $file.file")
-          project.logger.debug("Exelude against groovy files $groovySourceSet.groovy.files")
           file.file in groovySourceSet.groovy.files
         }
 
@@ -154,14 +154,15 @@ class GroovyAndroidPlugin implements Plugin<Project> {
 
       groovyTask.doFirst { GroovyCompile task ->
         def androidRunTime = project.files(getRuntimeJars(androidPlugin, androidExtension))
-        task.classpath = androidRunTime + javaTask.classpath
+        def kotlinFiles = project.files(getKotlinClassFiles(variantDataName))
+        task.classpath = androidRunTime + javaTask.classpath + kotlinFiles
         task.groovyClasspath = task.classpath
-
-        project.logger.debug("Java compilerArgs $javaTask.options.compilerArgs")
-        groovyTask.options.compilerArgs += javaTask.options.compilerArgs
-        project.logger.debug("Groovy CompilerArgs $groovyTask.options.compilerArgs")
-        groovyTask.groovyOptions.javaAnnotationProcessing = true
+        task.options.compilerArgs += javaTask.options.compilerArgs
+        task.groovyOptions.javaAnnotationProcessing = true
       }
+
+      log.debug('Groovy classpath: {}', groovyTask.classpath.files)
+      log.debug('Groovy compiler args {}', groovyTask.options.compilerArgs)
 
       javaTask.finalizedBy(groovyTask)
     }
@@ -264,5 +265,17 @@ class GroovyAndroidPlugin implements Plugin<Project> {
 
   private static VariantManager getVariantManager(BasePlugin plugin) {
     return plugin.variantManager
+  }
+
+  private getKotlinClassFiles(String variantName) {
+    // kotlin plugin exists
+    def kotlin = project.plugins.findPlugin('kotlin-android')
+    if (kotlin != null) {
+      def kotlinCopyTask = project.tasks.findByName("copy${variantName.capitalize()}KotlinClasses")
+      return kotlinCopyTask.kotlinOutputDir
+    }
+
+    // empty list to avoid null issues when adding to FileCollection
+    return Collections.emptyList()
   }
 }

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/GroovyAndroidPluginSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/GroovyAndroidPluginSpec.groovy
@@ -130,6 +130,7 @@ class GroovyAndroidPluginSpec extends Specification implements AndroidFileHelper
     def groovyTasks = project.tasks.withType(GroovyCompile)
 
     then:
+    !groovyTasks.isEmpty()
     groovyTasks.each { task ->
       assert task.sourceCompatibility == version
       assert task.targetCompatibility == version

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/KotlinSupportSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/functional/KotlinSupportSpec.groovy
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package groovyx.functional
+
+import static groovyx.internal.TestProperties.androidPluginVersion
+import static groovyx.internal.TestProperties.buildToolsVersion
+import static groovyx.internal.TestProperties.compileSdkVersion
+
+/**
+ * Allows Kotlin and Groovy to play nicely with each other.
+ * https://github.com/groovy/groovy-android-gradle-plugin/issues/139
+ */
+class KotlinSupportSpec extends FunctionalSpec {
+
+  def "should compile with kotlin dependencies"() {
+    given:
+    file("settings.gradle") << "rootProject.name = 'test-app'"
+
+    buildFile << """
+      buildscript {
+        repositories {
+          maven { url "${localRepo.toURI()}" }
+          jcenter()
+        }
+        dependencies {
+          classpath 'com.android.tools.build:gradle:$androidPluginVersion'
+          classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:$PLUGIN_VERSION'
+          classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.2'
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'kotlin-android' // must be applied before groovy
+      apply plugin: 'groovyx.android'
+
+      repositories {
+        jcenter()
+      }
+
+      android {
+        compileSdkVersion $compileSdkVersion
+        buildToolsVersion '$buildToolsVersion'
+
+        defaultConfig {
+          minSdkVersion 16
+          targetSdkVersion $compileSdkVersion
+
+          versionCode 1
+          versionName '1.0.0'
+
+          testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+        }
+
+        buildTypes {
+          debug {
+            applicationIdSuffix '.dev'
+          }
+        }
+
+        compileOptions {
+          sourceCompatibility '1.7'
+          targetCompatibility '1.7'
+        }
+      }
+
+      dependencies {
+        compile 'org.codehaus.groovy:groovy:2.4.11:grooid'
+        compile 'org.jetbrains.kotlin:kotlin-stdlib-jre7:1.1.2'
+
+        androidTestCompile 'com.android.support.test:runner:0.5'
+        androidTestCompile 'com.android.support.test:rules:0.5'
+
+        testCompile 'junit:junit:4.12'
+      }
+
+      // force unit test types to be assembled too
+      android.testVariants.all { variant ->
+        tasks.getByName('assemble').dependsOn variant.assemble
+      }
+    """
+
+    file('src/main/AndroidManifest.xml') << """
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="groovyx.test">
+
+        <application
+            android:allowBackup="true"
+            android:label="Test App">
+          <activity
+              android:name=".MainActivity"
+              android:label="Test App">
+            <intent-filter>
+              <action android:name="android.intent.action.MAIN"/>
+              <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+          </activity>
+        </application>
+
+      </manifest>
+    """.trim()
+
+    file('src/main/res/layout/activity_main.xml') << """
+      <?xml version="1.0" encoding="utf-8"?>
+      <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+      >
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Hello Groovy!"
+            android:gravity="center"
+            android:textAppearance="?android:textAppearanceLarge"
+        />
+
+      </FrameLayout>
+    """.trim()
+
+    file('src/main/groovy/groovyx/test/MainActivity.groovy') << """
+      package groovyx.test
+
+      import android.app.Activity
+      import android.os.Bundle
+      import groovy.transform.CompileStatic
+
+      @CompileStatic
+      class MainActivity extends Activity {
+        @Override void onCreate(Bundle savedInstanceState) {
+          super.onCreate(savedInstanceState)
+          contentView = R.layout.activity_main
+          
+          def value = new SimpleTest().getValue()
+        }
+      }
+    """
+
+    file('src/main/java/groovyx/test/SimpleTest.kt') << """
+      package groovyx.test
+
+      class SimpleTest {
+        val value: String get() = "Hello World"
+      }
+    """
+
+    file('src/test/groovy/groovyx/test/JvmTest.groovy') << """
+      package groovyx.test
+
+      import org.junit.Test
+
+      class JvmTest {
+        @Test void shouldCompile() {
+          assert 10 * 2 == 20
+        }
+      }
+    """
+
+    file('src/androidTest/groovy/groovyx/test/AndroidTest.groovy') << """
+      package groovyx.test
+
+      import android.support.test.runner.AndroidJUnit4
+      import android.test.suitebuilder.annotation.SmallTest
+      import groovy.transform.CompileStatic
+      import org.junit.Before
+      import org.junit.Test
+      import org.junit.runner.RunWith
+
+      @RunWith(AndroidJUnit4)
+      @SmallTest
+      @CompileStatic
+      class AndroidTest {
+        @Test void shouldCompile() {
+          assert 5 * 2 == 10
+        }
+      }
+    """
+
+    when:
+    copyTestDir()
+    run 'assemble', 'test'
+
+    then:
+    noExceptionThrown()
+    file('build/outputs/apk/test-app-debug.apk').exists()
+    file('build/intermediates/classes/debug/groovyx/test/MainActivity.class').exists()
+    file('build/intermediates/classes/debug/groovyx/test/SimpleTest.class').exists()
+    file('build/intermediates/classes/androidTest/debug/groovyx/test/AndroidTest.class').exists()
+    file('build/intermediates/classes/test/debug/groovyx/test/JvmTest.class').exists()
+    file('build/intermediates/classes/test/release/groovyx/test/JvmTest.class').exists()
+  }
+}


### PR DESCRIPTION
You can now intermix Java, Kotlin, and Groovy files all in the same
project. This pull request adds compiled Kotlin class files to
GroovyCompile's classpath allowing these classes to be referenced
inside of Groovy files.

Fixes: #139