### PR TITLE
Updated Compilation Tasks Requirements

### DIFF
--- a/groovy-android-gradle-plugin/src/main/groovy/groovyx/GroovyAndroidPlugin.groovy
+++ b/groovy-android-gradle-plugin/src/main/groovy/groovyx/GroovyAndroidPlugin.groovy
@@ -74,6 +74,7 @@ class GroovyAndroidPlugin implements Plugin<Project> {
       def sourceSetPath = project.file("src/$sourceSetName/groovy")
 
       if (!sourceSetPath.exists()) {
+        log.debug('SourceSet path does not exists for {} {}', sourceSetName, sourceSetPath)
         return
       }
 
@@ -128,8 +129,6 @@ class GroovyAndroidPlugin implements Plugin<Project> {
       providers.each { SourceProvider provider ->
         def groovySourceSet = provider.convention.plugins['groovy'] as GroovySourceSet
         if (groovySourceSet == null) {
-          // no source set skip task for this set
-          project.tasks.remove(groovyTask)
           return
         }
 
@@ -148,6 +147,14 @@ class GroovyAndroidPlugin implements Plugin<Project> {
           }
         }
       }
+
+      // no sources for groovy to compile skip the groovy task
+      if (groovyTask.source.empty) {
+        log.debug('no groovy sources found for {} removing groovy task', variantDataName)
+        project.tasks.remove(groovyTask)
+        return
+      }
+      log.debug('groovy sources for {}: {}', variantDataName, groovyTask.source.files)
 
       def additionalSourceFiles = getGeneratedSourceDirs(variantData)
       groovyTask.source(*additionalSourceFiles)

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/GroovyAndroidPluginSpec.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/GroovyAndroidPluginSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,15 @@ class GroovyAndroidPluginSpec extends Specification implements AndroidFileHelper
 
     // Android Plugin Requires this file to exist with parsable XML
     createSimpleAndroidManifest()
+    createSimpleGroovyFile()
+    file('src/androidTest/groovy/groovyx/SimpleAndroidTest.groovy') << """
+      package groovyx
+      class SimpleAndroidTest { }
+    """
+    file('src/test/groovy/groovyx/SimpleTest.groovy') << """
+      package groovyx 
+      class SimpleTest { }
+    """
 
     when:
     project.evaluate()
@@ -122,15 +131,16 @@ class GroovyAndroidPluginSpec extends Specification implements AndroidFileHelper
       }
     }
 
-    // Android Plugin Reqires this file to exist with parsable XML
+    // Android Plugin Requires this file to exist with parsable XML
     createSimpleAndroidManifest()
+    createSimpleGroovyFile()
 
     when:
     project.evaluate()
     def groovyTasks = project.tasks.withType(GroovyCompile)
 
     then:
-    !groovyTasks.isEmpty()
+    groovyTasks.size() == 2
     groovyTasks.each { task ->
       assert task.sourceCompatibility == version
       assert task.targetCompatibility == version

--- a/groovy-android-gradle-plugin/src/test/groovy/groovyx/internal/AndroidFileHelper.groovy
+++ b/groovy-android-gradle-plugin/src/test/groovy/groovyx/internal/AndroidFileHelper.groovy
@@ -27,4 +27,19 @@ trait AndroidFileHelper implements FileHelper {
           package="groovyx.test" />
     """.trim()
   }
+
+  void createSimpleGroovyFile() {
+    file('src/main/groovy/groovyx/Simple.groovy') << """
+      package groovyx
+      
+      import groovy.transform.CompileStatic
+      
+      @CompileStatic
+      class Simple {
+        void doWork() {
+          'Hello World'
+        }
+      }
+    """
+  }
 }


### PR DESCRIPTION
The original way this was implemented it not prevent the task from
running. Now if there are no sources the task is removed and
the should be skipped properly.