### PR TITLE
Revert build-info-extractor-gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,10 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:3.0.0'
     classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:1.2.0'
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.5.4'
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+    classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.4.12'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
-    classpath 'com.gradle:build-scan-plugin:1.10'
+    classpath 'com.gradle:build-scan-plugin:1.10.1'
     classpath 'com.gradle.publish:plugin-publish-plugin:0.9.9'
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2G -Dfile.encoding=UTF-8 -XX:+CMSClassUnloadingEnabled -XX:+CMSPermGenSweepingEnabled
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.configureondemand=true


### PR DESCRIPTION
4.4.12 seems to work, 4.5.0 not so much.