### PR TITLE
Update README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -236,6 +236,9 @@ android {
   packagingOptions {
       exclude 'META-INF/services/org.codehaus.groovy.transform.ASTTransformation'
       exclude 'META-INF/services/org.codehaus.groovy.runtime.ExtensionModule'
+      // you may need to exclude other files if you get "duplicate files during packaging of APK"
+      exclude 'META-INF/groovy-release-info.properties'
+      exclude 'META-INF/LICENSE'      
   }
 }
 ----


### PR DESCRIPTION
I got "duplicate files during packaging of APK" after adding groovy-json dependency, so I had to exclude more `META-INF/` files to be able to generate apk and use JsonSlurper.